### PR TITLE
SBOMをデプロイ前にスキャンする （⚠️マージするとスキャンでCIがこけます）

### DIFF
--- a/.github/workflows/main_actions-demo-2506.yml
+++ b/.github/workflows/main_actions-demo-2506.yml
@@ -39,6 +39,18 @@ jobs:
             ${{ github.workspace }}/build/libs/demo-0.0.1-SNAPSHOT.jar
             ${{ github.workspace }}/build/reports/application.cdx.json
       
+      - name: Install Grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Scan SBOM with Grype
+        run: |
+          grype sbom:${{ github.workspace }}/build/reports/application.cdx.json \
+            --fail-on high \
+            --only-fixed \
+            --output table
+
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## 概要

- GitHub Actionsでビルド時に生成したSBOMをデプロイ前にスキャンします
- 脆弱性が見つかったらデプロイジョブをfailさせます